### PR TITLE
Reenable caffe

### DIFF
--- a/cuda7.5-cudnn5/Dockerfile
+++ b/cuda7.5-cudnn5/Dockerfile
@@ -24,6 +24,52 @@ MAINTAINER Bethge Lab <opensource@bethgelab.org>
 #            python-caffe-nv=$CAFFE_PKG_VERSION && \
 #    rm -rf /var/lib/apt/lists/*
 
+
+# Installation procedure from https://github.com/BVLC/caffe/blob/master/docker/standalone/gpu/Dockerfile
+# Note: This works only for python2 right now.
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        wget \
+        libatlas-base-dev \
+        libboost-all-dev \
+        libgflags-dev \
+        libgoogle-glog-dev \
+        libhdf5-serial-dev \
+        libleveldb-dev \
+        liblmdb-dev \
+        libopencv-dev \
+        libprotobuf-dev \
+        libsnappy-dev \
+        protobuf-compiler \
+        python-dev \
+        python-numpy \
+        python-pip \
+        python-scipy && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CAFFE_ROOT=/opt/caffe
+WORKDIR $CAFFE_ROOT
+
+# FIXME: clone a specific git tag and use ARG instead of ENV once DockerHub supports this.
+ENV CLONE_TAG=master
+
+RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/BVLC/caffe.git . && \
+    for req in $(cat python/requirements.txt) pydot; do pip install $req; done && \
+    mkdir build && cd build && \
+    cmake -DUSE_CUDNN=1 .. && \
+    make -j"$(nproc)"
+
+ENV PYCAFFE_ROOT $CAFFE_ROOT/python
+ENV PYTHONPATH $PYCAFFE_ROOT:$PYTHONPATH
+ENV PATH $CAFFE_ROOT/build/tools:$PYCAFFE_ROOT:$PATH
+RUN echo "$CAFFE_ROOT/build/lib" >> /etc/ld.so.conf.d/caffe.conf && ldconfig
+
+WORKDIR $HOME
+
+
 # Install TensorFlow GPU version
 # ------------------------------
 RUN pip2 --no-cache-dir install \


### PR DESCRIPTION
I am using the installation procedure from the caffe
docker containers. This builds for me and I can import
caffe in python2.

Signed-off-by: Matthias Kümmerer matthias@matthias-k.org
